### PR TITLE
Add External Offset sub-component to Take Action component

### DIFF
--- a/build-tools/templates/component/COMPONENT_NAME.component.js.tpl
+++ b/build-tools/templates/component/COMPONENT_NAME.component.js.tpl
@@ -2,10 +2,10 @@
 
 import React from 'react';
 
-import TranslatableComponent from '../translatable/translatable.component';
+import Translatable from './../../lib/base_classes/translatable';
 import template from './<%= componentNameLowerCase %>.rt.html'
 
-class <%=  componentNameCamelCase %>Component extends TranslatableComponent {
+class <%=  componentNameCamelCase %>Component extends Translatable {
 
   constructor(props, context){
     super(props, context);

--- a/build-tools/templates/component/COMPONENT_NAME.rt.html.tpl
+++ b/build-tools/templates/component/COMPONENT_NAME.rt.html.tpl
@@ -9,5 +9,7 @@
   <div class="cc-component__nav">
     <button rt-if="this.route_key !== 'get_started'" class="btn">{this.t('Previous')}</button>
     <button rt-if="this.route_key !== 'take_action'" class="btn">{this.t('Next')}</button>
+    <a rt-if="this.route_key !== 'get_started'" onClick="{this.router.previous.bind(this.router)}">{this.t('Previous')}</a>
+    <a rt-if="this.route_key !== 'take_action'" onClick="{this.router.next.bind(this.router)}">{this.t('Next')}</a>
   </div>
 </div>

--- a/server/assets/translations/en.json
+++ b/server/assets/translations/en.json
@@ -131,7 +131,12 @@
     "route_path": "take_action",
     "tons_saved": "Tons saved",
     "dollars_saved": "Dollars saved",
-    "upfront_cost": "Upfront cost"
+    "upfront_cost": "Upfront cost",
+    "external_offset": {
+      "tons_co2_per_year": "tons CO2/year",
+      "monthly_gift": "monthly gift",
+      "dollar_sign": "$"
+    }
   },
   "graphs": {
     "your_footprint": "Your footprint",
@@ -156,7 +161,8 @@
     "average_food_footprint": "Average Food Footprint",
     "average_shopping_footprint": "Average Shopping Footprint",
     "comparison": "Comparison",
-    "total_action_savings": "Annual Savings"
+    "total_action_savings": "Annual Savings",
+    "average_action_savings": "Average Savings"
   },
   "categories": {
     "result_transport_total": "Travel",

--- a/shared/components/get_started/get_started.component.js
+++ b/shared/components/get_started/get_started.component.js
@@ -210,7 +210,7 @@ class GetStartedComponent extends Panel {
 
   get income_tick_labels(){
     let get_started = this,
-        width = window.outerWidth;
+        width = window.innerWidth;
     if (width < 400){
       return {
         1: get_started.t('Avg'),

--- a/shared/components/get_started/get_started.scss
+++ b/shared/components/get_started/get_started.scss
@@ -22,7 +22,7 @@
 #location_mode_btn_group {
   white-space:nowrap;
   max-width:100%;
-  overflow-x:scroll;
+  overflow-x:auto;
   a {
     float:none;
     width:80px;

--- a/shared/components/graphs/graphs.component.js
+++ b/shared/components/graphs/graphs.component.js
@@ -24,7 +24,7 @@ class GraphsComponent extends Panel {
 
   componentDidMount() {
     let graphs = this;
-    if (window.outerWidth < 992) {
+    if (window.innerWidth < 992) {
       graphs.setState({
         show_chart: false
       });
@@ -67,7 +67,7 @@ class GraphsComponent extends Panel {
   }
 
   get graph_dimensions(){
-    let width = window.outerWidth,
+    let width = window.innerWidth,
         dimensions = {
           outer_width: width * 0.8
         };

--- a/shared/components/layout/layout.scss
+++ b/shared/components/layout/layout.scss
@@ -29,7 +29,7 @@ a { cursor: pointer; }
 	margin-bottom:5px;
 	text-align: center;
 	max-width:100%;
-  overflow-x: scroll;
+  overflow-x: auto;
   overflow-y: hidden;
   margin: 0 auto;
   white-space: nowrap;

--- a/shared/components/take_action/external_offset/external_offset.component.js
+++ b/shared/components/take_action/external_offset/external_offset.component.js
@@ -1,0 +1,50 @@
+/*global module*/
+
+import React from 'react';
+
+import Translatable from './../../../lib/base_classes/translatable';
+import template from './external_offset.rt.html'
+
+class ExternalOffsetComponent extends Translatable {
+
+  constructor(props, context){
+    super(props, context);
+    let external_offset = this;
+    external_offset.state = {}
+  }
+
+  get total_footprint() {
+    let external_offset = this;
+    return external_offset.state_manager.state.user_footprint['result_grand_total']
+  }
+
+  get display_total_footprint() {
+    let external_offset = this;
+    return Math.round(external_offset.total_footprint)
+  }
+
+  get display_monthly_offset() {
+    let external_offset = this,
+    price_per_ton = external_offset.state_manager.state.external_offset.carbon_price_per_ton;
+    return Math.round((external_offset.total_footprint * price_per_ton) / 12)
+  }
+
+  get display_offset_description() {
+    let external_offset = this;
+    return external_offset.state_manager.state.external_offset.description
+  }
+
+  get offset_url() {
+    let external_offset = this;
+    return external_offset.state_manager.state.external_offset.offset_url
+  }
+
+  render(){
+    return template.call(this);
+  }
+
+}
+
+ExternalOffsetComponent.NAME = 'ExternalOffset';
+
+module.exports = ExternalOffsetComponent;

--- a/shared/components/take_action/external_offset/external_offset.rt.html
+++ b/shared/components/take_action/external_offset/external_offset.rt.html
@@ -1,0 +1,25 @@
+<div class="cc-component" id="external_offset">
+
+  <div class="external-offset__impact">
+    <div class="external-offset__footprint">
+      <h5>{this.display_total_footprint}</h5>
+      <p>{this.t('take_action.external_offset.tons_co2_per_year')}</p>
+    </div>
+
+    <div class="external-offset__equals">
+      <span>=</span>
+    </div>
+
+    <div class="external-offset__price">
+      <h5>{this.t('take_action.external_offset.dollar_sign')}{this.display_monthly_offset}</h5>
+      <p>{this.t('take_action.external_offset.monthly_gift')}</p>
+    </div>
+  </div>
+  <div class="external-offset__description">
+    <p>{this.display_offset_description}</p>
+  </div>
+
+  <div class="external-offset__call-to-action">
+    <a href="{this.offset_url}" class="btn btn-success">OFFSET NOW</a>
+  </div>
+</div>

--- a/shared/components/take_action/external_offset/external_offset.scss
+++ b/shared/components/take_action/external_offset/external_offset.scss
@@ -1,0 +1,59 @@
+#external_offset {
+
+  .external-offset__impact {
+    height: 100px;
+    clear: both;
+
+    .external-offset__footprint,
+    .external-offset__price {
+      float: left;
+      width: 45%;
+      display: inline-block;
+      h5 {
+        color: #696969;
+        font-size: 3em;
+      }
+      p {
+        font-size: 0.9em;
+        color: #999;
+      }
+    }
+
+    .external-offset__footprint {
+      text-align: right;
+      padding-right: 5%;
+    }
+
+    .external-offset__price {
+      padding-left: 5%;
+    }
+
+    .external-offset__equals {
+      float: left;
+      display: inline-block;
+      text-align: center;
+      font-size: 3em;
+      color: #339900;
+      font-weight: bold;
+    }
+  }
+
+  .external-offset__description {
+    width: 80%;
+    text-align: center;
+    margin: 20px auto 20px;
+  }
+
+  .external-offset__call-to-action {
+    text-align: center;
+    margin-bottom: 35px;
+
+    .btn {
+      width: 100%;
+      font-weight: bold;
+      font-size: 1.2em;
+      padding: 12px 12px;
+    }
+  }
+
+}

--- a/shared/components/take_action/external_offset/external_offset.test.js
+++ b/shared/components/take_action/external_offset/external_offset.test.js
@@ -1,0 +1,14 @@
+/*global describe it expect console*/
+
+import TestUtils from 'react-addons-test-utils';
+import React from 'react';
+
+import ExternalOffset from './external_offset.component';
+
+describe('ExternalOffset component', ()=>{
+  it('renders without problems', (done)=>{
+      external_offset = TestUtils.renderIntoDocument(React.createElement(ExternalOffset) );
+      expect(external_offset.state).toEqual({});
+      done();
+  });
+});

--- a/shared/components/take_action/take_action.component.js
+++ b/shared/components/take_action/take_action.component.js
@@ -26,6 +26,11 @@ class TakeActionComponent extends Panel {
     return this.action_keys;
   }
 
+  get external_offset_set(){
+    let e_o = this.state_manager.state.external_offset;
+    return Object.keys(e_o).length !== 0 && e_o.constructor === Object
+  }
+
   get result_takeaction_pounds(){
     return this.state_manager['result_takeaction_pounds'];
   }

--- a/shared/components/take_action/take_action.rt.html
+++ b/shared/components/take_action/take_action.rt.html
@@ -1,45 +1,46 @@
+<rt-require dependency="./external_offset/external_offset.component" as="ExternalOffset"/>
 <main class="cc-component container container-md" id="take_action">
   <header class="cc-component__header">
     <div>
       <img src="/assets/img/{this.route_key}-black.svg"/>
-      <h4>{this.title}</h4>
+      <h4>{this.t('take_action.title')}</h4>
     </div>
     <span class="cc-component__byline">{this.t('take_action.byline')}</span>
   </header>
 
-  <div class="cc-component__form">
+  <ExternalOffset rt-if="this.external_offset_set"></ExternalOffset>
 
-  <div>
-    <div rt-repeat="action in this.actions"
-      key="{action.key}">
-      <div class="take-action__action-heading"
-        rt-class="{'take-action__action-heading--taken': action.taken}"
-        onClick="{this.toggleActionDetails.bind(this, action)}">
-        <h5>{action.display_name}</h5>
-      </div>
-      <div class="take-action__action-body" rt-class="{hidden: !action.detailed}">
-        <div>
-          <div class="take-action__savings-amount">{action.tons_saved}</div>
-          <div class="take-action__savings-label">{this.t('take_action.tons_saved')}</div>
+  <div class="cc-component__form">
+    <div>
+      <div rt-repeat="action in this.actions"
+        key="{action.key}">
+        <div class="take-action__action-heading"
+          rt-class="{'take-action__action-heading--taken': action.taken}"
+          onClick="{this.toggleActionDetails.bind(this, action)}">
+          <h5>{action.display_name}</h5>
         </div>
-        <div>
-          <div class="take-action__savings-amount">${action.dollars_saved}</div>
-          <div class="take-action__savings-label">{this.t('take_action.dollars_saved')}</div>
+        <div class="take-action__action-body" rt-class="{hidden: !action.detailed}">
+          <div>
+            <div class="take-action__savings-amount">{action.tons_saved}</div>
+            <div class="take-action__savings-label">{this.t('take_action.tons_saved')}</div>
+          </div>
+          <div>
+            <div class="take-action__savings-amount">${action.dollars_saved}</div>
+            <div class="take-action__savings-label">{this.t('take_action.dollars_saved')}</div>
+          </div>
+          <div>
+            <div class="take-action__savings-amount">${action.upfront_cost}</div>
+            <div class="take-action__savings-label">{this.t('take_action.upfront_cost')}</div>
+          </div>
+          <button class="btn btn-default"
+            onClick="{this.toggleAction.bind(this, action)}">
+            <i class="fa" rt-class="{'fa-check-square-o': !action.taken, 'fa-check-square': action.taken}"></i>
+          </button>
         </div>
-        <div>
-          <div class="take-action__savings-amount">${action.upfront_cost}</div>
-          <div class="take-action__savings-label">{this.t('take_action.upfront_cost')}</div>
-        </div>
-        <button class="btn btn-default"
-          onClick="{this.toggleAction.bind(this, action)}">
-          <i class="fa" rt-class="{'fa-check-square-o': !action.taken, 'fa-check-square': action.taken}"></i>
-        </button>
       </div>
     </div>
-
   </div>
 
-  </div>
   <div id="take_action_savings">
     <span class="label label-info">{this.displayTakeactionSavings('result_takeaction_pounds')} {this.t('take_action.tons_saved')}</span><br/>
     <span class="label label-info">${this.displayTakeactionSavings('result_takeaction_dollars')} {this.t('take_action.dollars_saved')}</span><br/>

--- a/shared/components/take_action/take_action.scss
+++ b/shared/components/take_action/take_action.scss
@@ -3,6 +3,10 @@
   .take-action__detail-toggle {
     float: right;
   }
+
+  .cc-component__nav {
+    margin-top: 20px;
+  }
 }
 
 .take-action__savings-amount {

--- a/shared/lib/base_classes/panel.js
+++ b/shared/lib/base_classes/panel.js
@@ -18,7 +18,7 @@ export default class Panel extends mixin(Translatable, routable, footprintable, 
   }
 
   get slider_width(){
-    let width = window.outerWidth * 0.8;
+    let width = window.innerWidth * 0.8;
     width = Math.min(MAX_SLIDER_WIDTH, width);
     width = Math.max(MIN_SLIDER_WIDTH, width);
     return width

--- a/shared/lib/state_manager/state_manager.js
+++ b/shared/lib/state_manager/state_manager.js
@@ -19,7 +19,7 @@ export default class StateManager {
 
   constructor(){
     var state_manager = this;
-    state_manager.state = {average_footprint: {}, user_footprint: {}};
+    state_manager.state = {average_footprint: {}, user_footprint: {}, external_offset: {}};
   }
 
   get category_colors(){
@@ -130,8 +130,23 @@ export default class StateManager {
     return Promise.resolve();
   }
 
+  receiveExternalOffset() {
+    let state_manager = this;
+
+    window.addEventListener('message', ((event) => {
+      // optional origin check:
+      // if(event.origin !== 'http://localhost:8080') return;
+
+      let data = JSON.parse(event.data);
+      Object.assign(state_manager.state.external_offset, data)
+    }),false);
+
+  }
+
   getInitialData(){
     let state_manager = this;
+    state_manager.receiveExternalOffset()
+
     // we'll load past user answers and get CC results here.
     return state_manager.checkLocalStorage();
   }


### PR DESCRIPTION
This sub-component is shown when messages are received from external pages.
So far messages can be received from any page.

We should consider whitelisting the URLs that embed the widget.

The counter-part is located here: https://github.com/arbolista-dev/cc-calculator-widget/pull/1
