### PR TITLE
Confirmation for Get Started value changes

### DIFF
--- a/server/assets/translations/en.json
+++ b/server/assets/translations/en.json
@@ -62,7 +62,9 @@
         "United States": "United States",
         "average_household_size": "Avg (2.5)",
         "restore_defaults": "Your answers are saved in browser storage.",
-        "restore_defaults_button": "Click here to reset to defaults"
+        "restore_defaults_button": "Click here to reset to defaults",
+        "update_answers_hint": "Updating your location, household size and annual household income overwrites your previously entered answers.",
+        "update_answers_confirmed": "Confirm"
     },
     "travel": {
         "title": "Travel",

--- a/shared/components/pages/get_started/get_started.rt.html
+++ b/shared/components/pages/get_started/get_started.rt.html
@@ -49,6 +49,23 @@
 
 	</div>
 
+	<div className="modal fade" id="update_answers_reset" tabindex="-1" role="dialog">
+		<div className="modal-dialog modal-sm" role="document">
+			<div className="modal-content">
+				<div className="modal-body">
+					<p>{this.t('get_started.update_answers_hint')}</p>
+					<p>
+						<a type="button" className="btn btn-default btn-danger"
+							onClick="{this.updateAnswersConfirmed.bind(this)}"
+							data-dismiss="modal">
+							{this.t('get_started.update_answers_confirmed')}
+						</a>
+					</p>
+				</div>
+			</div>
+		</div>
+	</div>
+
 	<div className="cc-component__nav">
 		<a onClick="{this.router.next.bind(this.router)}">{this.t('Next')}</a>
 	</div>

--- a/shared/components/pages/take_action/action/action.component.js
+++ b/shared/components/pages/take_action/action/action.component.js
@@ -233,7 +233,8 @@ class ActionComponent extends Translatable {
   }
 
   updateFootprintParams(params){
-    this.props.userFootprintUpdated(params);
+    const updated_params = Object.assign({}, {input_changed: 1}, params);
+    this.props.userFootprintUpdated(updated_params);
   }
 
   updateTakeaction(params){

--- a/shared/lib/mixins/footprintable.js
+++ b/shared/lib/mixins/footprintable.js
@@ -141,7 +141,8 @@ export let footprintable = {
   },
 
   updateFootprintParams(updated_params){
-    this.props.userFootprintUpdated(updated_params);
+    const params = ({}).hasOwnProperty.call(updated_params, 'input_location_mode') ? updated_params : Object.assign({}, {input_changed: 1}, updated_params);
+    this.props.userFootprintUpdated(params);
   },
 
   updateFootprintInput(event){

--- a/shared/reducers/user_footprint/user_footprint.reducers.js
+++ b/shared/reducers/user_footprint/user_footprint.reducers.js
@@ -122,7 +122,6 @@ const ACTIONS = {
     setLocalStorageItem('user_footprint', merged_data);
 
     let updated = state.set('data', merged_data)
-                       .setIn(['data', 'input_changed'], 1)
                        .set('loading', false);
 
     return fromJS(updated);


### PR DESCRIPTION
**Trello**: https://trello.com/c/Vftkt7xj/93-critical-assumptions-should-change-based-on-location-see-energy-prices-for-old-calculator

**Fix**: Changes to income, size and location need to be confirmed after the user has altered values in other components. The triggered updates are stored in UI Redux state until they confirmed.

**Smoke test**:

1. @ Get Started: Update location, household size and income and make sure no confirmation is needed
2. @ Travel: Update any value to make sure the user footprint is changed.
3. @ Get Started: Updating location, household size and income should trigger a confirmation dialog. Upon 'Confirm' the new values are accepted and user footprint is reset. (Check: Your Total Footprint === Similar Household)