### PR TITLE
Email confirmation (in progress) 

### DIFF
--- a/client/api/real/user.api.js
+++ b/client/api/real/user.api.js
@@ -130,6 +130,31 @@ function listLocations() {
   });
 }
 
+function needActivate(jwt) {
+  return new Promise((fnResolve, fnReject) => {
+    superagent.get(`${BASE}/user/activate`)
+      .set('Authorization', jwt)
+      .end((err, res) => {
+        if (err) fnReject(err);
+        else {
+          fnResolve(res.body);
+        }
+      });
+  });
+}
+function sendConfirmation(jwt) {
+  return new Promise((fnResolve, fnReject) => {
+    superagent.post(`${BASE}/user/activate`)
+      .set('Authorization', jwt)
+      .end((err, res) => {
+        if (err) fnReject(err);
+        else {
+          fnResolve(res.body);
+        }
+      });
+  });
+}
+
 export { addUser,
   loginUser,
   loginUserFacebook,
@@ -138,4 +163,6 @@ export { addUser,
   forgotPassword,
   setLocation,
   listLeaders,
-  listLocations };
+  listLocations,
+  needActivate,
+  sendConfirmation };

--- a/client/api/real/user.api.js
+++ b/client/api/real/user.api.js
@@ -155,6 +155,20 @@ function sendConfirmation(jwt) {
   });
 }
 
+function changePassword(input) {
+  return new Promise((fnResolve, fnReject) => {
+    superagent.post(`${BASE}/user/reset`)
+      .set('Content-Type', 'application/json; charset=UTF-8')
+      .send(JSON.stringify(input))
+      .end((err, res) => {
+        if (err) fnReject(err);
+        else {
+          fnResolve(res.body);
+        }
+      });
+  });
+}
+
 export { addUser,
   loginUser,
   loginUserFacebook,
@@ -165,4 +179,5 @@ export { addUser,
   listLeaders,
   listLocations,
   needActivate,
-  sendConfirmation };
+  sendConfirmation,
+  changePassword };

--- a/server/assets/translations/en.json
+++ b/server/assets/translations/en.json
@@ -11,6 +11,12 @@
         "public": "Yes, my results can be published.",
         "submit": "Sign up"
     },
+    "reset":{
+        "title":"Change your password",
+        "password": "New password",
+        "submit":"Change password",
+        "confirm":"You change your password successfully"
+    },
     "login": {
         "title": "Login",
         "route_path": "login",
@@ -21,7 +27,9 @@
         "facebook":"Login or Sign up with Facebook"
     },
     "confirmation":{
-        "message":"Your email has not been confirmed, "
+        "message":"Your email has not been confirmed, ",
+        "successful":"Your account has been confirmed!",
+        "error":"Your link has expired please try again"
     },
     "logout": {
         "title": "Logout"

--- a/server/assets/translations/en.json
+++ b/server/assets/translations/en.json
@@ -15,7 +15,7 @@
         "title":"Change your password",
         "password": "New password",
         "submit":"Change password",
-        "confirm":"You change your password successfully"
+        "confirm":"You have successfully changed your password."
     },
     "login": {
         "title": "Login",
@@ -4636,7 +4636,9 @@
             "non-existent": "Please log in again."
         },
         "password-reset": {
-            "expired": "Your password reset link has expired. Please request a new one by visiting 'Forgot your password'."
+            "expired": "Your password reset link has expired. Please request a new one by visiting 'Forgot your password'.",
+            "user-non-existent": "User with this email address does not exist. Please make sure you entered it correctly or sign up as a new user.",
+            "req-non-existent": "This password reset link is invalid or you haven't requested one to be sent to your email address."
         },
         "reset-token": {
             "corrupt": "Your password reset link is invalid. Please request a new one by visiting 'Forgot your password'."

--- a/server/assets/translations/en.json
+++ b/server/assets/translations/en.json
@@ -20,6 +20,9 @@
         "submit": "Login",
         "facebook":"Login or Sign up with Facebook"
     },
+    "confirmation":{
+        "message":"Your email has not been confirmed, "
+    },
     "logout": {
         "title": "Logout"
     },

--- a/shared/components/common/alerts/alerts.component.js
+++ b/shared/components/common/alerts/alerts.component.js
@@ -20,6 +20,12 @@ class AlertsComponent extends Translatable {
     return this.props.list.length !== 0;
   }
 
+  alertAction(action) {
+    if (action === 'confirmAccount') {
+      this.props.confirmAccount();
+    }
+  }
+
   translateAlert(alert) {
     const alerts = this;
     if (alert.needs_i18n) {
@@ -31,6 +37,7 @@ class AlertsComponent extends Translatable {
 
 AlertsComponent.propTypes = {
   list: React.PropTypes.array.isRequired,
+  confirmAccount: React.PropTypes.func,
 };
 
 AlertsComponent.NAME = 'Alerts';

--- a/shared/components/common/alerts/alerts.rt.html
+++ b/shared/components/common/alerts/alerts.rt.html
@@ -3,6 +3,8 @@
       key="{alertIndex}"
       rt-class="{'alert-success': alert.type === 'success', 'alert-danger': alert.type === 'danger'}"
       rt-repeat="alert in this.props.list">
-      {this.translateAlert(alert)}
+      {this.translateAlert(alert)} 
+      <a key="{actionIndex}" href="#" onClick="() => this.alertAction(action.action)" class="alert-link" rt-repeat="action in alert.actions">
+      	 {action.text} </a> 
     </div>
 </div>

--- a/shared/components/layout/layout.component.js
+++ b/shared/components/layout/layout.component.js
@@ -47,6 +47,10 @@ class LayoutComponent extends Panel {
     return this.props.ui.getIn(['alerts', 'shared']).toJS();
   }
 
+  get alert_list_activation() {
+    return this.props.ui.getIn(['alerts', 'activation']).toJS();
+  }
+
   get current_route() {
     return this.router.routes.getRoute(this.current_route_name);
   }

--- a/shared/components/layout/layout.rt.html
+++ b/shared/components/layout/layout.rt.html
@@ -40,7 +40,9 @@
 		<div rt-if="this.external_offset.banner_url" id="external_banner">
 			<img src="{this.external_offset.banner_url}" rt-props="{style: this.external_offset.banner_style}"/>
 		</div>
-		<Alerts list="{this.alert_list}" />
+		<Alerts list="{this.alert_list_activation}" rt-props="{confirmAccount: this.props.confirmAccount}" />
+		<Alerts list="{this.alert_list}"  />
+
 		<main>
 			<ForgotPassword rt-if="this.current_route_name === 'ForgotPassword'" />
 			<Settings rt-if="this.current_route_name === 'Settings'" />

--- a/shared/components/pages/settings/settings.component.js
+++ b/shared/components/pages/settings/settings.component.js
@@ -13,8 +13,26 @@ class SettingsComponent extends Panel {
     settings.state = {};
   }
 
+  componentDidMount() {
+    if (this.props.location.getIn(['query', 'type']) === 'confirm') {
+      const alert = {
+        id: 'shared',
+        data: [{
+          needs_i18n: true,
+          type: 'success',
+          message: 'confirmation.successful',
+        }],
+      };
+      this.props.pushAlert(alert);
+    }
+  }
+
   render() {
     return template.call(this);
+  }
+
+  get reset_password() {
+    return this.props.location.getIn(['query', 'type']) === 'reset' && this.props.auth.get('canReset');
   }
 
 }

--- a/shared/components/pages/settings/settings.rt.html
+++ b/shared/components/pages/settings/settings.rt.html
@@ -1,13 +1,15 @@
 <rt-require dependency="./user/login/login.component" as="Login"/>
 <rt-require dependency="./user/sign_up/sign_up.component" as="SignUp"/>
 <rt-require dependency="./user/logout/logout.component" as="Logout"/>
+<rt-require dependency="./user/reset/reset.component" as="Reset"/>
 <main className="cc-component container container-md" id="settings">
   <div className="cc-component__form">
-    <Login rt-if="!this.user_authenticated" />
-    <SignUp rt-if="!this.user_authenticated" />
-    <Logout rt-if="this.user_authenticated" />
+    <Reset rt-if="this.reset_password" />
+    <Login rt-if="!this.user_authenticated && !this.reset_password" />
+    <SignUp rt-if="!this.user_authenticated && !this.reset_password" />
+    <Logout rt-if="this.user_authenticated && !this.reset_password" />
 
-    <div className="panel panel-coolclimate">
+    <div className="panel panel-coolclimate" rt-if="!this.reset_password">
       <div className="panel-heading">
         {this.t('settings.restore_defaults')}
       </div>

--- a/shared/components/pages/settings/user/reset/reset.component.js
+++ b/shared/components/pages/settings/user/reset/reset.component.js
@@ -1,0 +1,90 @@
+/* global module*/
+
+import React from 'react';
+import Panel from 'shared/lib/base_classes/panel';
+import { validateParameter } from 'shared/lib/utils/utils';
+import authContainer, { authPropTypes } from 'shared/containers/auth.container';
+import template from './reset.rt.html';
+
+class ResetComponent extends Panel {
+
+  constructor(props, context) {
+    super(props, context);
+    const reset = this;
+    reset.valid = {
+      password: false,
+    };
+    reset.state = {
+      password: '',
+    };
+  }
+
+  render() {
+    return template.call(this);
+  }
+
+  paramValid(param) {
+    const reset = this;
+
+    if (reset.state[param].length > 0) {
+      return reset.valid[param];
+    }
+    return true;
+  }
+
+  validateAll() {
+    const reset = this;
+    const all_valid = Object.values(reset.valid).filter(item => item === false);
+    if (all_valid.length > 0) {
+      const alerts = {
+        id: 'reset',
+        data: [],
+      };
+      Object.keys(reset.valid).forEach((key) => {
+        if (reset.valid[key] === false) {
+          const item = {
+            type: 'danger',
+            message: `${reset.t(`reset.${key}`)} ${reset.t('errors.invalid')}`,
+          };
+          alerts.data.push(item);
+        }
+      });
+      reset.props.pushAlert(alerts);
+      return false;
+    }
+    return true;
+  }
+
+  updateInput(event) {
+    event.preventDefault();
+
+    const reset = this;
+    const api_key = event.target.dataset.api_key;
+    const update = {
+      [api_key]: event.target.value,
+    };
+
+    reset.valid[api_key] = validateParameter(update);
+    reset.setState(update);
+  }
+
+
+  submitReset(event) {
+    const reset = this;
+    event.preventDefault();
+    if (reset.validateAll()) {
+      const state_input = {
+        id: Number(reset.props.location.getIn(['query', 'id'])),
+        token: reset.props.location.getIn(['query', 'token']),
+        password: reset.state.password,
+      };
+      reset.props.resetPassword(state_input);
+    }
+  }
+
+}
+
+ResetComponent.NAME = 'Reset';
+ResetComponent.propTypes = authPropTypes;
+
+module.exports = authContainer(ResetComponent);

--- a/shared/components/pages/settings/user/reset/reset.rt.html
+++ b/shared/components/pages/settings/user/reset/reset.rt.html
@@ -1,0 +1,31 @@
+<rt-require dependency="shared/components/common/alerts/alerts.component" as="Alerts"/>
+
+<main className="panel panel-coolclimate" id="reset">
+    <div className="panel-heading">
+        {this.t('reset.title')}
+    </div>
+
+    <div className="panel-body cc-component__form form-horizontal">
+        <div className="cc-component__auth">
+          <form onsubmit="{this.submitReset.bind(this)}">
+            <div className="form-group">
+                <label for="inputPassword" className="control-label">
+                  {this.t('reset.password')}
+                </label>
+                <input type="password" className="form-control" id="inputPassword"
+                rt-class="{error: !this.paramValid('password')}"
+                onChange="{this.updateInput.bind(this)}"
+                data-api_key="password"
+                value="{this.state.password}"
+                placeholder="{this.t('reset.password')}"/>
+            </div>
+            <div className="cc-component__auth-submit">
+                <button className="btn btn-default"
+                onClick="{this.submitReset.bind(this)}">
+                  {this.t('reset.submit')}
+                </button>
+            </div>
+          </form>
+        </div>
+    </div>
+</main>

--- a/shared/components/pages/settings/user/reset/reset.scss
+++ b/shared/components/pages/settings/user/reset/reset.scss
@@ -1,0 +1,13 @@
+#reset {
+
+  .error {
+    border-color: #e97266;
+  }
+
+  #location_suggestions {
+    margin-top: 35px;
+    z-index: 9999;
+    width: 75%;
+    margin-left: 25%;
+  }
+}

--- a/shared/components/pages/settings/user/reset/reset.test.js
+++ b/shared/components/pages/settings/user/reset/reset.test.js
@@ -1,0 +1,14 @@
+/* global describe it expect*/
+
+import TestUtils from 'react-addons-test-utils';
+import wrapWithContext from '../../../../application/application.component.mock';
+
+import Reset from './reset.component';
+
+describe('Reset component', () => {
+  it('renders without problems', (done) => {
+    const reset = TestUtils.renderIntoDocument(wrapWithContext(Reset));
+    expect(TestUtils.findRenderedComponentWithType(reset, Reset).state).not.toBe(null);
+    done();
+  });
+});

--- a/shared/containers/auth.container.js
+++ b/shared/containers/auth.container.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { signup, login, loginFacebook, logout, requestNewPassword } from 'shared/reducers/auth/auth.actions';
+import { signup, login, loginFacebook, logout, requestNewPassword, resetPassword } from 'shared/reducers/auth/auth.actions';
 import { pushAlert, resetAlerts } from 'shared/reducers/ui/ui.actions';
 
 const mapStateToProps = state => ({
@@ -37,6 +37,10 @@ const mapDispatchToProps = dispatch => ({
   requestNewPassword: (params) => {
     requestNewPassword.assignTo(dispatch);
     requestNewPassword(params);
+  },
+  resetPassword: (params) => {
+    resetPassword.assignTo(dispatch);
+    resetPassword(params);
   },
 });
 

--- a/shared/containers/footprint.container.js
+++ b/shared/containers/footprint.container.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { ensureDefaults, averageFootprintUpdated } from 'shared/reducers/average_footprint/average_footprint.actions';
 import { ensureFootprintComputed, userFootprintUpdated, userFootprintReset, updatedFootprintComputed, updateTakeactionResult } from 'shared/reducers/user_footprint/user_footprint.actions';
 import { updateUI, pushAlert, resetAlerts } from 'shared/reducers/ui/ui.actions';
+import { sendEmailConfirmation } from 'shared/reducers/auth/auth.actions';
 
 const mapStateToProps = state => ({
   location: state.location,
@@ -48,6 +49,9 @@ const mapDispatchToProps = dispatch => ({
   },
   pushAlert: (payload) => {
     dispatch(pushAlert(payload));
+  },
+  confirmAccount: () => {
+    dispatch(sendEmailConfirmation());
   },
   resetAlerts: () => {
     resetAlerts.assignTo(dispatch);

--- a/shared/lib/router/router.js
+++ b/shared/lib/router/router.js
@@ -143,8 +143,8 @@ export default class Router {
 
   static currentWindowLocation() {
     const pathname = window.location.pathname;
-    const query = window.location.search;
-    return { pathname, query };
+    const search = window.location.search;
+    return { pathname, search };
   }
 
   // Use this when createHistory is a hash history

--- a/shared/lib/state_manager/state_manager.js
+++ b/shared/lib/state_manager/state_manager.js
@@ -66,6 +66,7 @@ export default class StateManager {
         forgot_password: [],
         leaders: [],
         shared: [],
+        activation: [],
       },
       show_leaders_chart: false,
       alert_exists: false,

--- a/shared/lib/state_manager/state_manager.js
+++ b/shared/lib/state_manager/state_manager.js
@@ -109,6 +109,7 @@ export default class StateManager {
     return Object.assign({
       auth: fromJS({
         data: state_manager.auth_storage || {},
+        canReset: true,
       }),
       average_footprint: fromJS({
         data: state_manager.average_footprint_storage || state_manager.default_inputs,

--- a/shared/reducers/auth/auth.actions.js
+++ b/shared/reducers/auth/auth.actions.js
@@ -15,10 +15,10 @@ const verifyActivation = createAction('Verify Activation');
 const activationError = createAction('Activation error');
 const sendEmailConfirmation = createAction('Send confirmation');
 const resetPassword = createAction('Reset password');
-const resetedPassword = createAction('Reset password');
+const resetPasswordSuccess = createAction('Reset password successfully');
 const resetPasswordError = createAction('Reset password error');
 
 export { signup, login, loginFacebook, loggedIn, signedUp, logout, loggedOut,
   requestNewPassword, newPasswordRequested, authError, processActivation,
   verifyActivation, activationError, sendEmailConfirmation,
-  resetPassword, resetedPassword, resetPasswordError };
+  resetPassword, resetPasswordSuccess, resetPasswordError };

--- a/shared/reducers/auth/auth.actions.js
+++ b/shared/reducers/auth/auth.actions.js
@@ -14,7 +14,11 @@ const processActivation = createAction('Process Activation');
 const verifyActivation = createAction('Verify Activation');
 const activationError = createAction('Activation error');
 const sendEmailConfirmation = createAction('Send confirmation');
+const resetPassword = createAction('Reset password');
+const resetedPassword = createAction('Reset password');
+const resetPasswordError = createAction('Reset password error');
 
 export { signup, login, loginFacebook, loggedIn, signedUp, logout, loggedOut,
   requestNewPassword, newPasswordRequested, authError, processActivation,
-  verifyActivation, activationError, sendEmailConfirmation };
+  verifyActivation, activationError, sendEmailConfirmation,
+  resetPassword, resetedPassword, resetPasswordError };

--- a/shared/reducers/auth/auth.actions.js
+++ b/shared/reducers/auth/auth.actions.js
@@ -10,6 +10,11 @@ const loggedOut = createAction('User successfully logged out.');
 const requestNewPassword = createAction('Request new password upon forgotten.');
 const newPasswordRequested = createAction('New password got requested');
 const authError = createAction('Auth error.');
+const processActivation = createAction('Process Activation');
+const verifyActivation = createAction('Verify Activation');
+const activationError = createAction('Activation error');
+const sendEmailConfirmation = createAction('Send confirmation');
 
 export { signup, login, loginFacebook, loggedIn, signedUp, logout, loggedOut,
-  requestNewPassword, newPasswordRequested, authError };
+  requestNewPassword, newPasswordRequested, authError, processActivation,
+  verifyActivation, activationError, sendEmailConfirmation };

--- a/shared/reducers/ui/ui.reducers.js
+++ b/shared/reducers/ui/ui.reducers.js
@@ -42,7 +42,9 @@ const ACTIONS = {
   [resetAlerts]: (state) => {
     let updated = state;
     Object.keys(state.get('alerts').toJS()).forEach((type) => {
-      updated = state.setIn(['alerts', type], new List());
+      if (type !== 'activation') {
+        updated = updated.setIn(['alerts', type], new List());
+      }
     });
     updated = updated.set('alert_exists', false);
     return updated;


### PR DESCRIPTION
**Trello**

https://trello.com/c/TGUji80s/123-server-ui-re-implement-email-confirmation

**Summary**

* Show a persistent message when the account hasn't been confirmed
* Show a button to resend the confirmation email
* Endpoint for password reset and email confirmation 

**Smoke test**

* Create a new account, must display the message for account confirmation
* Click the Confirm now link, must re-send a confirmation email
* The confirmation email must use the calculator endpoint instead api endpoint
* Click in "Forgot my password", 
* The password reset email must use the calculator endpoint instead api endpoint